### PR TITLE
Fix URL handling in fuzz tests

### DIFF
--- a/fuzz/fuzz_get_test.go
+++ b/fuzz/fuzz_get_test.go
@@ -6,7 +6,6 @@ import (
 	"fuzzing-api/logger"
 	"fuzzing-api/utils"
 	"io/ioutil"
-	"net/url"
 	"testing"
 )
 
@@ -20,8 +19,7 @@ func FuzzGetEndpoint(f *testing.F) {
 	f.Add(config.Endpoints.Get)
 
 	f.Fuzz(func(t *testing.T, seed string) {
-		escapedSeed := url.QueryEscape(seed)
-		url := fmt.Sprintf("%s%s", config.BaseURL, escapedSeed)
+		url := fmt.Sprintf("%s%s", config.BaseURL, seed)
 
 		resp, statusCode, duration, err := client.Get(url)
 		if err != nil {

--- a/fuzz/fuzz_post_test.go
+++ b/fuzz/fuzz_post_test.go
@@ -7,7 +7,6 @@ import (
 	"fuzzing-api/logger"
 	"fuzzing-api/utils"
 	"io/ioutil"
-	"net/url"
 	"testing"
 )
 
@@ -21,8 +20,7 @@ func FuzzPostEndpoint(f *testing.F) {
 	f.Add(config.Endpoints.Post)
 
 	f.Fuzz(func(t *testing.T, seed string) {
-		escapedSeed := url.QueryEscape(seed)
-		url := fmt.Sprintf("%s%s", config.BaseURL, escapedSeed)
+		url := fmt.Sprintf("%s%s", config.BaseURL, seed)
 
 		body := config.RequestBody
 		bodyJSON, _ := json.Marshal(body)


### PR DESCRIPTION
## Summary
- remove unnecessary URL escaping in fuzz tests

## Testing
- `go vet ./...`
- `go test ./...` *(fails: Forbidden - network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e3bcfdbd88322b66f7c8e0223ec06