### PR TITLE
Add fuzzing support for more HTTP verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Fuzzing API Testing
 
-This project is a small Go framework for fuzz testing HTTP API endpoints. It currently supports GET and POST requests, reads endpoint settings from `config/config.json`, and logs each request outcome.
+This project is a small Go framework for fuzz testing HTTP API endpoints. It currently supports GET, POST, PUT, PATCH, and DELETE requests, reads endpoint settings from `config/config.json`, and logs each request outcome.
 
 ## Features
 
-- **GET and POST fuzzing**: Exercise API endpoints with Go fuzz tests.
+- **HTTP verb fuzzing**: Exercise GET, POST, PUT, PATCH, and DELETE endpoints with Go fuzz tests.
 - **JSON configuration**: Manage the base URL, endpoints, and POST body from one file.
 - **Request logging**: Log method, endpoint, seed, response status, duration, request body, and response body.
 - **Local client tests**: Validate the API client without calling external services.
@@ -20,7 +20,8 @@ fuzzing-api/
 |   `-- config.json          # Base URL, endpoints, and request body
 |-- fuzz/
 |   |-- fuzz_get_test.go     # Fuzz tests for GET requests
-|   `-- fuzz_post_test.go    # Fuzz tests for POST requests
+|   |-- fuzz_post_test.go    # Fuzz tests for POST requests
+|   `-- fuzz_write_methods_test.go # Fuzz tests for PUT, PATCH, and DELETE requests
 |-- logger/
 |   `-- logger.go            # Request logging helper
 |-- utils/
@@ -39,7 +40,10 @@ The `config/config.json` file uses this shape:
   "baseURL": "https://example.com/api/v1",
   "endpoints": {
     "get": "/resources",
-    "post": "/resources"
+    "post": "/resources",
+    "put": "/resources/1",
+    "patch": "/resources/1",
+    "delete": "/resources/1"
   },
   "requestBody": {
     "id": 1,
@@ -69,6 +73,9 @@ Run fuzz tests:
 ```bash
 FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
 FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzPostEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzPutEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzPatchEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzDeleteEndpoint -fuzztime=30s ./fuzz
 ```
 
 On PowerShell:
@@ -77,6 +84,9 @@ On PowerShell:
 $env:FUZZ_API_EXTERNAL = "1"
 go test -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
 go test -fuzz=FuzzPostEndpoint -fuzztime=30s ./fuzz
+go test -fuzz=FuzzPutEndpoint -fuzztime=30s ./fuzz
+go test -fuzz=FuzzPatchEndpoint -fuzztime=30s ./fuzz
+go test -fuzz=FuzzDeleteEndpoint -fuzztime=30s ./fuzz
 ```
 
 The fuzz tests call the API configured in `config/config.json`, so they are opt-in and require network access plus a reachable target service.

--- a/api/api_client.go
+++ b/api/api_client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -65,30 +66,51 @@ func joinPath(basePath, endpointPath string) string {
 
 // Get performs a GET request against an endpoint relative to BaseURL.
 func (c *APIClient) Get(endpoint string) (*http.Response, int, time.Duration, error) {
-	requestURL, err := c.ResolveEndpoint(endpoint)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
-	start := time.Now()
-	resp, err := c.Client.Get(requestURL)
-	duration := time.Since(start)
-	if err != nil {
-		return nil, 0, duration, err
-	}
-
-	return resp, resp.StatusCode, duration, nil
+	return c.Request(http.MethodGet, endpoint, "")
 }
 
 // Post performs a POST request against an endpoint relative to BaseURL.
 func (c *APIClient) Post(endpoint string, data string) (*http.Response, int, time.Duration, error) {
+	return c.Request(http.MethodPost, endpoint, data)
+}
+
+// Put performs a PUT request against an endpoint relative to BaseURL.
+func (c *APIClient) Put(endpoint string, data string) (*http.Response, int, time.Duration, error) {
+	return c.Request(http.MethodPut, endpoint, data)
+}
+
+// Patch performs a PATCH request against an endpoint relative to BaseURL.
+func (c *APIClient) Patch(endpoint string, data string) (*http.Response, int, time.Duration, error) {
+	return c.Request(http.MethodPatch, endpoint, data)
+}
+
+// Delete performs a DELETE request against an endpoint relative to BaseURL.
+func (c *APIClient) Delete(endpoint string) (*http.Response, int, time.Duration, error) {
+	return c.Request(http.MethodDelete, endpoint, "")
+}
+
+// Request performs an HTTP request against an endpoint relative to BaseURL.
+func (c *APIClient) Request(method, endpoint string, data string) (*http.Response, int, time.Duration, error) {
 	requestURL, err := c.ResolveEndpoint(endpoint)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 
+	var body io.Reader
+	if data != "" {
+		body = bytes.NewBufferString(data)
+	}
+
+	req, err := http.NewRequest(method, requestURL, body)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if data != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
 	start := time.Now()
-	resp, err := c.Client.Post(requestURL, "application/json", bytes.NewBufferString(data))
+	resp, err := c.Client.Do(req)
 	duration := time.Since(start)
 	if err != nil {
 		return nil, 0, duration, err

--- a/api/api_client_test.go
+++ b/api/api_client_test.go
@@ -63,6 +63,12 @@ func TestGetAndPost(t *testing.T) {
 				t.Fatalf("body = %q, want %q", body, `{"id":1}`)
 			}
 			w.WriteHeader(http.StatusCreated)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("method = %q", r.Method)
 		}
@@ -87,5 +93,32 @@ func TestGetAndPost(t *testing.T) {
 	resp.Body.Close()
 	if statusCode != http.StatusCreated {
 		t.Fatalf("POST status = %d, want %d", statusCode, http.StatusCreated)
+	}
+
+	resp, statusCode, _, err = client.Put("/Activities", `{"id":1}`)
+	if err != nil {
+		t.Fatalf("Put returned error: %v", err)
+	}
+	resp.Body.Close()
+	if statusCode != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d", statusCode, http.StatusOK)
+	}
+
+	resp, statusCode, _, err = client.Patch("/Activities", `{"id":1}`)
+	if err != nil {
+		t.Fatalf("Patch returned error: %v", err)
+	}
+	resp.Body.Close()
+	if statusCode != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want %d", statusCode, http.StatusOK)
+	}
+
+	resp, statusCode, _, err = client.Delete("/Activities")
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	resp.Body.Close()
+	if statusCode != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want %d", statusCode, http.StatusNoContent)
 	}
 }

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,10 @@
   "baseURL": "https://fakerestapi.azurewebsites.net/api/v1",
   "endpoints": {
     "get": "/Activities",
-    "post": "/Activities"
+    "post": "/Activities",
+    "put": "/Activities/1",
+    "patch": "/Activities/1",
+    "delete": "/Activities/1"
   },
   "requestBody": {
     "id": 1,

--- a/fuzz/fuzz_write_methods_test.go
+++ b/fuzz/fuzz_write_methods_test.go
@@ -1,0 +1,104 @@
+package fuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"fuzzing-api/api"
+	"fuzzing-api/logger"
+	"fuzzing-api/utils"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func FuzzPutEndpoint(f *testing.F) {
+	fuzzEndpoint(f, http.MethodPut, configuredPutEndpoint, true)
+}
+
+func FuzzPatchEndpoint(f *testing.F) {
+	fuzzEndpoint(f, http.MethodPatch, configuredPatchEndpoint, true)
+}
+
+func FuzzDeleteEndpoint(f *testing.F) {
+	fuzzEndpoint(f, http.MethodDelete, configuredDeleteEndpoint, false)
+}
+
+func fuzzEndpoint(f *testing.F, method string, configuredEndpoint func(*utils.Config) string, includeBody bool) {
+	if os.Getenv("FUZZ_API_EXTERNAL") != "1" {
+		f.Skip("establece FUZZ_API_EXTERNAL=1 para ejecutar fuzzing contra la API configurada")
+	}
+
+	config, err := utils.LoadConfig("../config/config.json")
+	if err != nil {
+		f.Fatalf("Error al cargar la configuracion: %v", err)
+	}
+
+	for _, seed := range writeMethodSeeds(configuredEndpoint(config)) {
+		f.Add(seed)
+	}
+
+	client := api.NewAPIClient(config.BaseURL)
+	f.Fuzz(func(t *testing.T, seed string) {
+		requestURL, err := client.ResolveEndpoint(seed)
+		if err != nil {
+			t.Skipf("Semilla con endpoint invalido %q: %v", seed, err)
+		}
+
+		var requestBody string
+		if includeBody {
+			bodyJSON, err := json.Marshal(config.RequestBody)
+			if err != nil {
+				t.Fatalf("Error al serializar el cuerpo %s: %v", method, err)
+			}
+			requestBody = string(bodyJSON)
+		}
+
+		resp, statusCode, duration, err := client.Request(method, seed, requestBody)
+		if err != nil {
+			logger.LogRequest(method, requestURL, seed, 0, duration, requestBody, fmt.Sprintf("Error: %v", err))
+			t.Errorf("Error en la solicitud %s: %v", method, err)
+			return
+		}
+		defer resp.Body.Close()
+
+		responseBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Error al leer la respuesta %s: %v", method, err)
+			return
+		}
+		logger.LogRequest(method, requestURL, seed, statusCode, duration, requestBody, string(responseBody))
+
+		if statusCode >= 500 {
+			t.Errorf("Error del servidor: %d para la semilla: %s", statusCode, seed)
+		}
+	})
+}
+
+func writeMethodSeeds(configuredEndpoint string) []string {
+	return []string{
+		configuredEndpoint,
+		"/Activities/0",
+		"/Activities/-1",
+		"/Activities/2147483647",
+		"/Activities/000001",
+		"/Activities/abc",
+		"/Activities/1.5",
+		"/Activities?validate=true&validate=false",
+		"/Activities?page=-1&pageSize=999999",
+		"/Activities/%2e%2e/%2e%2e",
+		"/Activities/%20",
+	}
+}
+
+func configuredPutEndpoint(config *utils.Config) string {
+	return config.Endpoints.Put
+}
+
+func configuredPatchEndpoint(config *utils.Config) string {
+	return config.Endpoints.Patch
+}
+
+func configuredDeleteEndpoint(config *utils.Config) string {
+	return config.Endpoints.Delete
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,8 +8,11 @@ import (
 type Config struct {
 	BaseURL   string `json:"baseURL"`
 	Endpoints struct {
-		Get  string `json:"get"`
-		Post string `json:"post"`
+		Get    string `json:"get"`
+		Post   string `json:"post"`
+		Put    string `json:"put"`
+		Patch  string `json:"patch"`
+		Delete string `json:"delete"`
 	} `json:"endpoints"`
 	RequestBody map[string]interface{} `json:"requestBody"`
 }


### PR DESCRIPTION
## Summary
- add a generic API client request method plus PUT, PATCH, and DELETE helpers
- extend configuration with endpoints for PUT, PATCH, and DELETE
- add fuzz targets for PUT, PATCH, and DELETE using shared request logic
- update client tests and README usage examples

## Verification
- go test ./...
- FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzGetEndpoint -fuzztime=10s ./fuzz
- FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzPostEndpoint -fuzztime=10s ./fuzz
- FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzPutEndpoint -fuzztime=10s ./fuzz
- FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzPatchEndpoint -fuzztime=10s ./fuzz
- FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzDeleteEndpoint -fuzztime=10s ./fuzz