### PR TITLE
Add verb-specific fuzz seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This project is a small Go framework for fuzz testing HTTP API endpoints. It cur
 
 ## Features
 
-- **HTTP verb fuzzing**: Exercise GET, POST, PUT, PATCH, and DELETE endpoints with Go fuzz tests.
+- **HTTP verb fuzzing**: Exercise GET, POST, PUT, PATCH, and DELETE endpoints with separate Go fuzz targets.
+- **Verb-specific seeds**: Keep endpoint and request-body seeds tuned to each HTTP method.
 - **JSON configuration**: Manage the base URL, endpoints, and POST body from one file.
 - **Request logging**: Log method, endpoint, seed, response status, duration, request body, and response body.
 - **Reproducible findings**: Store request errors and 5xx responses as JSON Lines artifacts for later triage.
@@ -22,7 +23,8 @@ fuzzing-api/
 |-- fuzz/
 |   |-- fuzz_get_test.go     # Fuzz tests for GET requests
 |   |-- fuzz_post_test.go    # Fuzz tests for POST requests
-|   `-- fuzz_write_methods_test.go # Fuzz tests for PUT, PATCH, and DELETE requests
+|   |-- fuzz_write_methods_test.go # Fuzz tests for PUT, PATCH, and DELETE requests
+|   `-- seeds_test.go        # Verb-specific endpoint and body seeds
 |-- logger/
 |   |-- logger.go            # Request logging and findings helpers
 |   `-- logger_test.go       # Findings artifact tests
@@ -73,30 +75,43 @@ go test ./...
 Run fuzz tests:
 
 ```bash
-FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
-FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzPostEndpoint -fuzztime=30s ./fuzz
-FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzPutEndpoint -fuzztime=30s ./fuzz
-FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzPatchEndpoint -fuzztime=30s ./fuzz
-FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzDeleteEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzPostEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzPutEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzPatchEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzDeleteEndpoint -fuzztime=30s ./fuzz
 ```
 
 On PowerShell:
 
 ```powershell
 $env:FUZZ_API_EXTERNAL = "1"
-go test -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
-go test -fuzz=FuzzPostEndpoint -fuzztime=30s ./fuzz
-go test -fuzz=FuzzPutEndpoint -fuzztime=30s ./fuzz
-go test -fuzz=FuzzPatchEndpoint -fuzztime=30s ./fuzz
-go test -fuzz=FuzzDeleteEndpoint -fuzztime=30s ./fuzz
+go test -run=^$ -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
+go test -run=^$ -fuzz=FuzzPostEndpoint -fuzztime=30s ./fuzz
+go test -run=^$ -fuzz=FuzzPutEndpoint -fuzztime=30s ./fuzz
+go test -run=^$ -fuzz=FuzzPatchEndpoint -fuzztime=30s ./fuzz
+go test -run=^$ -fuzz=FuzzDeleteEndpoint -fuzztime=30s ./fuzz
 ```
 
 The fuzz tests call the API configured in `config/config.json`, so they are opt-in and require network access plus a reachable target service.
+The `-run=^$` flag keeps the command focused on the selected fuzz target instead of running the seed corpus for every fuzz test in the package first.
+
+Each fuzz target is intentionally run separately because each HTTP verb has different inputs worth mutating:
+
+| Target | Initial seeds | What it mutates |
+| --- | ---: | --- |
+| `FuzzGetEndpoint` | 11 | Endpoint paths, IDs, query strings, and encoded path segments |
+| `FuzzPostEndpoint` | 17 | POST endpoints plus request bodies for creation scenarios |
+| `FuzzPutEndpoint` | 17 | PUT endpoints plus full replacement request bodies |
+| `FuzzPatchEndpoint` | 19 | PATCH endpoints plus partial, null, unknown-field, and malformed bodies |
+| `FuzzDeleteEndpoint` | 10 | Endpoint paths, IDs, query strings, and encoded path segments |
+
+`POST`, `PUT`, and `PATCH` use two fuzz arguments: the endpoint seed and the request-body seed. The seed corpus keeps the campaign focused by testing all endpoint variants with the configured body, then testing body variants against the configured endpoint.
 
 When a fuzz test hits a request error or an HTTP 5xx response, it appends a reproducible finding to `artifacts/fuzz-findings.jsonl`. Override the output path with `FUZZ_API_FINDINGS`:
 
 ```bash
-FUZZ_API_FINDINGS=./tmp/findings.jsonl FUZZ_API_EXTERNAL=1 go test -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
+FUZZ_API_FINDINGS=./tmp/findings.jsonl FUZZ_API_EXTERNAL=1 go test -run=^$ -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
 ```
 
 On PowerShell:
@@ -104,7 +119,7 @@ On PowerShell:
 ```powershell
 $env:FUZZ_API_FINDINGS = ".\tmp\findings.jsonl"
 $env:FUZZ_API_EXTERNAL = "1"
-go test -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
+go test -run=^$ -fuzz=FuzzGetEndpoint -fuzztime=30s ./fuzz
 ```
 
 ## Requirements

--- a/fuzz/fuzz_get_test.go
+++ b/fuzz/fuzz_get_test.go
@@ -21,19 +21,7 @@ func FuzzGetEndpoint(f *testing.F) {
 	}
 
 	client := api.NewAPIClient(config.BaseURL)
-	for _, seed := range []string{
-		config.Endpoints.Get,
-		"/Activities/0",
-		"/Activities/-1",
-		"/Activities/2147483647",
-		"/Activities/000001",
-		"/Activities/abc",
-		"/Activities/1.5",
-		"/Activities?completed=true&completed=false",
-		"/Activities?page=-1&pageSize=999999",
-		"/Activities/%2e%2e/%2e%2e",
-		"/Activities/%20",
-	} {
+	for _, seed := range getEndpointSeeds(config) {
 		f.Add(seed)
 	}
 

--- a/fuzz/fuzz_post_test.go
+++ b/fuzz/fuzz_post_test.go
@@ -1,7 +1,6 @@
 package fuzz
 
 import (
-	"encoding/json"
 	"fmt"
 	"fuzzing-api/api"
 	"fuzzing-api/logger"
@@ -22,37 +21,18 @@ func FuzzPostEndpoint(f *testing.F) {
 	}
 
 	client := api.NewAPIClient(config.BaseURL)
-	for _, seed := range []string{
-		config.Endpoints.Post,
-		"/Activities/0",
-		"/Activities/-1",
-		"/Activities/2147483647",
-		"/Activities/000001",
-		"/Activities/abc",
-		"/Activities/1.5",
-		"/Activities?validate=true&validate=false",
-		"/Activities?page=-1&pageSize=999999",
-		"/Activities/%2e%2e/%2e%2e",
-		"/Activities/%20",
-	} {
-		f.Add(seed)
-	}
+	addEndpointBodySeeds(f.Add, postEndpointSeeds(config), postBodySeeds(config))
 
-	f.Fuzz(func(t *testing.T, seed string) {
+	f.Fuzz(func(t *testing.T, seed string, requestBody string) {
 		requestURL, err := client.ResolveEndpoint(seed)
 		if err != nil {
 			t.Skipf("Semilla con endpoint inválido %q: %v", seed, err)
 		}
 
-		bodyJSON, err := json.Marshal(config.RequestBody)
+		resp, statusCode, duration, err := client.Post(seed, requestBody)
 		if err != nil {
-			t.Fatalf("Error al serializar el cuerpo POST: %v", err)
-		}
-
-		resp, statusCode, duration, err := client.Post(seed, string(bodyJSON))
-		if err != nil {
-			logger.LogRequest("POST", requestURL, seed, 0, duration, string(bodyJSON), fmt.Sprintf("Error: %v", err))
-			if logErr := logger.LogFinding("POST", requestURL, seed, 0, duration, string(bodyJSON), "", err.Error()); logErr != nil {
+			logger.LogRequest("POST", requestURL, seed, 0, duration, requestBody, fmt.Sprintf("Error: %v", err))
+			if logErr := logger.LogFinding("POST", requestURL, seed, 0, duration, requestBody, "", err.Error()); logErr != nil {
 				t.Logf("Error al registrar el hallazgo POST: %v", logErr)
 			}
 			t.Errorf("Error en la solicitud POST: %v", err)
@@ -65,11 +45,11 @@ func FuzzPostEndpoint(f *testing.F) {
 			t.Errorf("Error al leer la respuesta POST: %v", err)
 			return
 		}
-		logger.LogRequest("POST", requestURL, seed, statusCode, duration, string(bodyJSON), string(respBody))
+		logger.LogRequest("POST", requestURL, seed, statusCode, duration, requestBody, string(respBody))
 
 		// Manejo de códigos HTTP.
 		if statusCode >= 500 {
-			if logErr := logger.LogFinding("POST", requestURL, seed, statusCode, duration, string(bodyJSON), string(respBody), ""); logErr != nil {
+			if logErr := logger.LogFinding("POST", requestURL, seed, statusCode, duration, requestBody, string(respBody), ""); logErr != nil {
 				t.Logf("Error al registrar el hallazgo POST: %v", logErr)
 			}
 			t.Errorf("Error del servidor: %d para la semilla: %s", statusCode, seed)

--- a/fuzz/fuzz_write_methods_test.go
+++ b/fuzz/fuzz_write_methods_test.go
@@ -1,7 +1,6 @@
 package fuzz
 
 import (
-	"encoding/json"
 	"fmt"
 	"fuzzing-api/api"
 	"fuzzing-api/logger"
@@ -13,18 +12,18 @@ import (
 )
 
 func FuzzPutEndpoint(f *testing.F) {
-	fuzzEndpoint(f, http.MethodPut, configuredPutEndpoint, true)
+	fuzzEndpointWithBody(f, http.MethodPut, putEndpointSeeds, putBodySeeds)
 }
 
 func FuzzPatchEndpoint(f *testing.F) {
-	fuzzEndpoint(f, http.MethodPatch, configuredPatchEndpoint, true)
+	fuzzEndpointWithBody(f, http.MethodPatch, patchEndpointSeeds, patchBodySeeds)
 }
 
 func FuzzDeleteEndpoint(f *testing.F) {
-	fuzzEndpoint(f, http.MethodDelete, configuredDeleteEndpoint, false)
+	fuzzEndpointWithoutBody(f, http.MethodDelete, deleteEndpointSeeds)
 }
 
-func fuzzEndpoint(f *testing.F, method string, configuredEndpoint func(*utils.Config) string, includeBody bool) {
+func fuzzEndpointWithBody(f *testing.F, method string, endpointSeeds func(*utils.Config) []string, bodySeeds func(*utils.Config) []string) {
 	if os.Getenv("FUZZ_API_EXTERNAL") != "1" {
 		f.Skip("establece FUZZ_API_EXTERNAL=1 para ejecutar fuzzing contra la API configurada")
 	}
@@ -34,24 +33,13 @@ func fuzzEndpoint(f *testing.F, method string, configuredEndpoint func(*utils.Co
 		f.Fatalf("Error al cargar la configuracion: %v", err)
 	}
 
-	for _, seed := range writeMethodSeeds(configuredEndpoint(config)) {
-		f.Add(seed)
-	}
+	addEndpointBodySeeds(f.Add, endpointSeeds(config), bodySeeds(config))
 
 	client := api.NewAPIClient(config.BaseURL)
-	f.Fuzz(func(t *testing.T, seed string) {
+	f.Fuzz(func(t *testing.T, seed string, requestBody string) {
 		requestURL, err := client.ResolveEndpoint(seed)
 		if err != nil {
 			t.Skipf("Semilla con endpoint invalido %q: %v", seed, err)
-		}
-
-		var requestBody string
-		if includeBody {
-			bodyJSON, err := json.Marshal(config.RequestBody)
-			if err != nil {
-				t.Fatalf("Error al serializar el cuerpo %s: %v", method, err)
-			}
-			requestBody = string(bodyJSON)
 		}
 
 		resp, statusCode, duration, err := client.Request(method, seed, requestBody)
@@ -81,30 +69,50 @@ func fuzzEndpoint(f *testing.F, method string, configuredEndpoint func(*utils.Co
 	})
 }
 
-func writeMethodSeeds(configuredEndpoint string) []string {
-	return []string{
-		configuredEndpoint,
-		"/Activities/0",
-		"/Activities/-1",
-		"/Activities/2147483647",
-		"/Activities/000001",
-		"/Activities/abc",
-		"/Activities/1.5",
-		"/Activities?validate=true&validate=false",
-		"/Activities?page=-1&pageSize=999999",
-		"/Activities/%2e%2e/%2e%2e",
-		"/Activities/%20",
+func fuzzEndpointWithoutBody(f *testing.F, method string, endpointSeeds func(*utils.Config) []string) {
+	if os.Getenv("FUZZ_API_EXTERNAL") != "1" {
+		f.Skip("establece FUZZ_API_EXTERNAL=1 para ejecutar fuzzing contra la API configurada")
 	}
-}
 
-func configuredPutEndpoint(config *utils.Config) string {
-	return config.Endpoints.Put
-}
+	config, err := utils.LoadConfig("../config/config.json")
+	if err != nil {
+		f.Fatalf("Error al cargar la configuracion: %v", err)
+	}
 
-func configuredPatchEndpoint(config *utils.Config) string {
-	return config.Endpoints.Patch
-}
+	for _, seed := range endpointSeeds(config) {
+		f.Add(seed)
+	}
 
-func configuredDeleteEndpoint(config *utils.Config) string {
-	return config.Endpoints.Delete
+	client := api.NewAPIClient(config.BaseURL)
+	f.Fuzz(func(t *testing.T, seed string) {
+		requestURL, err := client.ResolveEndpoint(seed)
+		if err != nil {
+			t.Skipf("Semilla con endpoint invalido %q: %v", seed, err)
+		}
+
+		resp, statusCode, duration, err := client.Request(method, seed, "")
+		if err != nil {
+			logger.LogRequest(method, requestURL, seed, 0, duration, "", fmt.Sprintf("Error: %v", err))
+			if logErr := logger.LogFinding(method, requestURL, seed, 0, duration, "", "", err.Error()); logErr != nil {
+				t.Logf("Error al registrar el hallazgo %s: %v", method, logErr)
+			}
+			t.Errorf("Error en la solicitud %s: %v", method, err)
+			return
+		}
+		defer resp.Body.Close()
+
+		responseBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Error al leer la respuesta %s: %v", method, err)
+			return
+		}
+		logger.LogRequest(method, requestURL, seed, statusCode, duration, "", string(responseBody))
+
+		if statusCode >= 500 {
+			if logErr := logger.LogFinding(method, requestURL, seed, statusCode, duration, "", string(responseBody), ""); logErr != nil {
+				t.Logf("Error al registrar el hallazgo %s: %v", method, logErr)
+			}
+			t.Errorf("Error del servidor: %d para la semilla: %s", statusCode, seed)
+		}
+	})
 }

--- a/fuzz/seeds_test.go
+++ b/fuzz/seeds_test.go
@@ -1,0 +1,144 @@
+package fuzz
+
+import (
+	"encoding/json"
+	"fuzzing-api/utils"
+)
+
+func getEndpointSeeds(config *utils.Config) []string {
+	return []string{
+		config.Endpoints.Get,
+		"/Activities/0",
+		"/Activities/-1",
+		"/Activities/2147483647",
+		"/Activities/000001",
+		"/Activities/abc",
+		"/Activities/1.5",
+		"/Activities?completed=true&completed=false",
+		"/Activities?page=-1&pageSize=999999",
+		"/Activities/%2e%2e/%2e%2e",
+		"/Activities/%20",
+	}
+}
+
+func postEndpointSeeds(config *utils.Config) []string {
+	return []string{
+		config.Endpoints.Post,
+		"/Activities",
+		"/Activities/",
+		"/Activities/0",
+		"/Activities/-1",
+		"/Activities/2147483647",
+		"/Activities/abc",
+		"/Activities?validate=true&validate=false",
+		"/Activities/%2e%2e/%2e%2e",
+		"/Activities/%20",
+	}
+}
+
+func putEndpointSeeds(config *utils.Config) []string {
+	return []string{
+		config.Endpoints.Put,
+		"/Activities/0",
+		"/Activities/-1",
+		"/Activities/2147483647",
+		"/Activities/000001",
+		"/Activities/abc",
+		"/Activities/1.5",
+		"/Activities/1?overwrite=true&overwrite=false",
+		"/Activities/%2e%2e/%2e%2e",
+		"/Activities/%20",
+	}
+}
+
+func patchEndpointSeeds(config *utils.Config) []string {
+	return []string{
+		config.Endpoints.Patch,
+		"/Activities/0",
+		"/Activities/-1",
+		"/Activities/2147483647",
+		"/Activities/000001",
+		"/Activities/abc",
+		"/Activities/1.5",
+		"/Activities/1?partial=true&partial=false",
+		"/Activities/%2e%2e/%2e%2e",
+		"/Activities/%20",
+	}
+}
+
+func deleteEndpointSeeds(config *utils.Config) []string {
+	return []string{
+		config.Endpoints.Delete,
+		"/Activities/0",
+		"/Activities/-1",
+		"/Activities/2147483647",
+		"/Activities/000001",
+		"/Activities/abc",
+		"/Activities/1.5",
+		"/Activities/1?force=true&force=false",
+		"/Activities/%2e%2e/%2e%2e",
+		"/Activities/%20",
+	}
+}
+
+func postBodySeeds(config *utils.Config) []string {
+	return []string{
+		configuredRequestBody(config),
+		`{}`,
+		`{"id":0,"title":"","dueDate":"0001-01-01T00:00:00Z","completed":false}`,
+		`{"id":-1,"title":"negative id","dueDate":"2026-01-01T00:00:00Z","completed":false}`,
+		`{"id":2147483647,"title":"max int id","dueDate":"9999-12-31T23:59:59Z","completed":true}`,
+		`{"id":"1","title":123,"dueDate":false,"completed":"yes"}`,
+		`{"unknown":"field","nested":{"value":[1,true,null]}}`,
+		`not-json`,
+	}
+}
+
+func putBodySeeds(config *utils.Config) []string {
+	return []string{
+		configuredRequestBody(config),
+		`{"id":1,"title":"","dueDate":"2026-01-01T00:00:00Z","completed":false}`,
+		`{"id":1,"title":"replacement","dueDate":"0001-01-01T00:00:00Z","completed":true}`,
+		`{"id":0,"title":"id mismatch","dueDate":"2026-01-01T00:00:00Z","completed":false}`,
+		`{"id":2147483647,"title":"large id","dueDate":"9999-12-31T23:59:59Z","completed":true}`,
+		`{"id":"1","title":null,"dueDate":123,"completed":null}`,
+		`[]`,
+		`not-json`,
+	}
+}
+
+func patchBodySeeds(config *utils.Config) []string {
+	return []string{
+		configuredRequestBody(config),
+		`{}`,
+		`{"title":""}`,
+		`{"title":null}`,
+		`{"completed":true}`,
+		`{"completed":null}`,
+		`{"dueDate":"not-a-date"}`,
+		`{"unknown":"field"}`,
+		`[]`,
+		`not-json`,
+	}
+}
+
+func addEndpointBodySeeds(add func(...any), endpoints []string, bodies []string) {
+	if len(endpoints) == 0 || len(bodies) == 0 {
+		return
+	}
+
+	for _, endpoint := range endpoints {
+		add(endpoint, bodies[0])
+	}
+	for _, body := range bodies[1:] {
+		add(endpoints[0], body)
+	}
+}
+
+func configuredRequestBody(config *utils.Config) string {
+	bodyJSON, err := json.Marshal(config.RequestBody)
+	if err != nil {
+		return `{}`
+	}
+	return string(bodyJSON)
+}


### PR DESCRIPTION
## Summary
- centralize verb-specific endpoint and body seeds for fuzz tests
- fuzz POST, PUT, and PATCH with endpoint plus request-body arguments
- document per-verb fuzz commands and seed counts in the README

## Tests
- `go test ./...`
- `go test -run=^$ -fuzz=FuzzGetEndpoint -fuzztime=1s ./fuzz`