### PR TITLE
ci: strengthen Go checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.go text eol=lf
+go.mod text eol=lf
+.github/workflows/*.yml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,18 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    name: Go tests
+    name: Go checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -16,7 +21,25 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.mod
+
+      - name: Verify module files
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Check formatting
+        run: |
+          files="$(gofmt -l .)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
+      - name: Run vet
+        run: go vet ./...
 
       - name: Run tests
-        run: go test ./...
+        run: go test -race -count=1 ./...


### PR DESCRIPTION
## Summary
- use the Go version declared in go.mod and enable setup-go caching
- add tidy, gofmt, vet, and race-enabled test checks
- add .gitattributes to keep Go/workflow files on LF line endings

## Validation
- gofmt -l .
- go mod tidy
- go vet ./...
- go test -count=1 ./...