### PR TITLE
[codex] refactor shared fuzz target execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project is a small Go framework for fuzz testing HTTP API endpoints. It cur
 
 - **HTTP verb fuzzing**: Exercise GET, POST, PUT, PATCH, and DELETE endpoints with separate Go fuzz targets.
 - **Verb-specific seeds**: Keep endpoint and request-body seeds tuned to each HTTP method.
+- **Shared fuzz execution**: Run all HTTP methods through common helpers for consistent logging, finding capture, and 5xx handling.
 - **JSON configuration**: Manage the base URL, endpoints, and POST body from one file.
 - **Request logging**: Log method, endpoint, seed, response status, duration, request body, and response body.
 - **Reproducible findings**: Store request errors and 5xx responses as JSON Lines artifacts for later triage.
@@ -21,9 +22,9 @@ fuzzing-api/
 |-- config/
 |   `-- config.json          # Base URL, endpoints, and request body
 |-- fuzz/
-|   |-- fuzz_get_test.go     # Fuzz tests for GET requests
-|   |-- fuzz_post_test.go    # Fuzz tests for POST requests
-|   |-- fuzz_write_methods_test.go # Fuzz tests for PUT, PATCH, and DELETE requests
+|   |-- fuzz_get_test.go     # GET fuzz target wrapper
+|   |-- fuzz_post_test.go    # POST fuzz target wrapper
+|   |-- fuzz_write_methods_test.go # Shared fuzz helpers plus PUT, PATCH, and DELETE wrappers
 |   `-- seeds_test.go        # Verb-specific endpoint and body seeds
 |-- logger/
 |   |-- logger.go            # Request logging and findings helpers

--- a/fuzz/fuzz_get_test.go
+++ b/fuzz/fuzz_get_test.go
@@ -1,60 +1,10 @@
 package fuzz
 
 import (
-	"fmt"
-	"fuzzing-api/api"
-	"fuzzing-api/logger"
-	"fuzzing-api/utils"
-	"io"
-	"os"
+	"net/http"
 	"testing"
 )
 
 func FuzzGetEndpoint(f *testing.F) {
-	if os.Getenv("FUZZ_API_EXTERNAL") != "1" {
-		f.Skip("establece FUZZ_API_EXTERNAL=1 para ejecutar fuzzing contra la API configurada")
-	}
-
-	config, err := utils.LoadConfig("../config/config.json")
-	if err != nil {
-		f.Fatalf("Error al cargar la configuración: %v", err)
-	}
-
-	client := api.NewAPIClient(config.BaseURL)
-	for _, seed := range getEndpointSeeds(config) {
-		f.Add(seed)
-	}
-
-	f.Fuzz(func(t *testing.T, seed string) {
-		requestURL, err := client.ResolveEndpoint(seed)
-		if err != nil {
-			t.Skipf("Semilla con endpoint inválido %q: %v", seed, err)
-		}
-
-		resp, statusCode, duration, err := client.Get(seed)
-		if err != nil {
-			logger.LogRequest("GET", requestURL, seed, 0, duration, "", fmt.Sprintf("Error: %v", err))
-			if logErr := logger.LogFinding("GET", requestURL, seed, 0, duration, "", "", err.Error()); logErr != nil {
-				t.Logf("Error al registrar el hallazgo GET: %v", logErr)
-			}
-			t.Errorf("Error en la solicitud GET: %v", err)
-			return
-		}
-		defer resp.Body.Close()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Errorf("Error al leer la respuesta GET: %v", err)
-			return
-		}
-		logger.LogRequest("GET", requestURL, seed, statusCode, duration, "", string(body))
-
-		// Manejo de códigos HTTP.
-		if statusCode >= 500 {
-			if logErr := logger.LogFinding("GET", requestURL, seed, statusCode, duration, "", string(body), ""); logErr != nil {
-				t.Logf("Error al registrar el hallazgo GET: %v", logErr)
-			}
-			t.Errorf("Error del servidor: %d para la semilla: %s", statusCode, seed)
-		}
-	})
+	fuzzEndpointWithoutBody(f, http.MethodGet, getEndpointSeeds)
 }

--- a/fuzz/fuzz_post_test.go
+++ b/fuzz/fuzz_post_test.go
@@ -1,58 +1,10 @@
 package fuzz
 
 import (
-	"fmt"
-	"fuzzing-api/api"
-	"fuzzing-api/logger"
-	"fuzzing-api/utils"
-	"io"
-	"os"
+	"net/http"
 	"testing"
 )
 
 func FuzzPostEndpoint(f *testing.F) {
-	if os.Getenv("FUZZ_API_EXTERNAL") != "1" {
-		f.Skip("establece FUZZ_API_EXTERNAL=1 para ejecutar fuzzing contra la API configurada")
-	}
-
-	config, err := utils.LoadConfig("../config/config.json")
-	if err != nil {
-		f.Fatalf("Error al cargar la configuración: %v", err)
-	}
-
-	client := api.NewAPIClient(config.BaseURL)
-	addEndpointBodySeeds(f.Add, postEndpointSeeds(config), postBodySeeds(config))
-
-	f.Fuzz(func(t *testing.T, seed string, requestBody string) {
-		requestURL, err := client.ResolveEndpoint(seed)
-		if err != nil {
-			t.Skipf("Semilla con endpoint inválido %q: %v", seed, err)
-		}
-
-		resp, statusCode, duration, err := client.Post(seed, requestBody)
-		if err != nil {
-			logger.LogRequest("POST", requestURL, seed, 0, duration, requestBody, fmt.Sprintf("Error: %v", err))
-			if logErr := logger.LogFinding("POST", requestURL, seed, 0, duration, requestBody, "", err.Error()); logErr != nil {
-				t.Logf("Error al registrar el hallazgo POST: %v", logErr)
-			}
-			t.Errorf("Error en la solicitud POST: %v", err)
-			return
-		}
-		defer resp.Body.Close()
-
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Errorf("Error al leer la respuesta POST: %v", err)
-			return
-		}
-		logger.LogRequest("POST", requestURL, seed, statusCode, duration, requestBody, string(respBody))
-
-		// Manejo de códigos HTTP.
-		if statusCode >= 500 {
-			if logErr := logger.LogFinding("POST", requestURL, seed, statusCode, duration, requestBody, string(respBody), ""); logErr != nil {
-				t.Logf("Error al registrar el hallazgo POST: %v", logErr)
-			}
-			t.Errorf("Error del servidor: %d para la semilla: %s", statusCode, seed)
-		}
-	})
+	fuzzEndpointWithBody(f, http.MethodPost, postEndpointSeeds, postBodySeeds)
 }


### PR DESCRIPTION
## Summary

Refactors the GET and POST fuzz targets so they use the same shared execution helpers as PUT, PATCH, and DELETE.

## Why

The previous GET and POST targets duplicated request execution, logging, finding capture, response reading, and 5xx handling logic. Routing them through the shared helpers keeps behavior consistent across HTTP methods and makes future changes easier to apply in one place.

## Impact

- `FuzzGetEndpoint` now delegates to `fuzzEndpointWithoutBody`.
- `FuzzPostEndpoint` now delegates to `fuzzEndpointWithBody`.
- The README documents the shared fuzz execution flow and updated fuzz file roles.

## Validation

- `go test ./...`
- `go vet ./...`