### PR TITLE
[codex] add fuzz runner artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ fuzzing-api/
 |-- logger/
 |   |-- logger.go            # Request logging and findings helpers
 |   `-- logger_test.go       # Findings artifact tests
+|-- scripts/
+|   `-- run-fuzz.ps1         # PowerShell runner that stores artifacts per execution
 |-- utils/
 |   |-- utils.go             # Configuration loading
 |   `-- validator.go         # HTTP status validator helper
@@ -71,6 +73,32 @@ Run all tests:
 
 ```bash
 go test ./...
+```
+
+Run every fuzz target on PowerShell and save artifacts per execution:
+
+```powershell
+.\scripts\run-fuzz.ps1 -FuzzTime 30s
+```
+
+The runner creates a timestamped directory under `artifacts/` for each execution:
+
+```plaintext
+artifacts/
+`-- 2026-06-28_10-30-15/
+    |-- FuzzGetEndpoint.log
+    |-- FuzzPostEndpoint.log
+    |-- FuzzPutEndpoint.log
+    |-- FuzzPatchEndpoint.log
+    |-- FuzzDeleteEndpoint.log
+    |-- fuzz-findings.jsonl
+    `-- summary.txt
+```
+
+By default the script keeps the latest 10 execution directories and removes older ones. Override that with `-KeepRuns`, or use `-KeepRuns 0` to disable cleanup:
+
+```powershell
+.\scripts\run-fuzz.ps1 -FuzzTime 5m -KeepRuns 20
 ```
 
 Run fuzz tests:

--- a/scripts/run-fuzz.ps1
+++ b/scripts/run-fuzz.ps1
@@ -1,0 +1,116 @@
+[CmdletBinding()]
+param(
+    [string]$FuzzTime = "30s",
+    [string]$ArtifactsRoot = "artifacts",
+    [int]$KeepRuns = 10,
+    [string[]]$Targets = @(
+        "FuzzGetEndpoint",
+        "FuzzPostEndpoint",
+        "FuzzPutEndpoint",
+        "FuzzPatchEndpoint",
+        "FuzzDeleteEndpoint"
+    ),
+    [switch]$StopOnFailure
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+$artifactsRootPath = Join-Path $repoRoot $ArtifactsRoot
+$runDir = Join-Path $artifactsRootPath $timestamp
+$findingsPath = Join-Path $runDir "fuzz-findings.jsonl"
+$summaryPath = Join-Path $runDir "summary.txt"
+
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$previousExternal = $env:FUZZ_API_EXTERNAL
+$previousFindings = $env:FUZZ_API_FINDINGS
+$results = @()
+
+try {
+    Push-Location $repoRoot
+
+    $env:FUZZ_API_EXTERNAL = "1"
+    $env:FUZZ_API_FINDINGS = $findingsPath
+
+    @(
+        "Fuzz run: $timestamp",
+        "Repository: $repoRoot",
+        "Fuzz time: $FuzzTime",
+        "Findings: $findingsPath",
+        "Targets: $($Targets -join ', ')",
+        ""
+    ) | Set-Content -Path $summaryPath
+
+    foreach ($target in $Targets) {
+        $logPath = Join-Path $runDir "$target.log"
+        $commandText = "go test -run=^$ -fuzz=$target -fuzztime=$FuzzTime ./fuzz"
+
+        Write-Host "Running $target for $FuzzTime"
+        @(
+            "Target: $target",
+            "Command: $commandText",
+            "Started: $(Get-Date -Format o)",
+            ""
+        ) | Set-Content -Path $logPath
+
+        & go test "-run=^$" "-fuzz=$target" "-fuzztime=$FuzzTime" "./fuzz" *>&1 |
+            Tee-Object -FilePath $logPath -Append
+
+        $exitCode = $LASTEXITCODE
+        $status = if ($exitCode -eq 0) { "PASS" } else { "FAIL" }
+        $results += [pscustomobject]@{
+            Target = $target
+            Status = $status
+            ExitCode = $exitCode
+            Log = $logPath
+        }
+
+        Add-Content -Path $logPath -Value @(
+            "",
+            "Finished: $(Get-Date -Format o)",
+            "Exit code: $exitCode"
+        )
+
+        if ($exitCode -ne 0 -and $StopOnFailure) {
+            break
+        }
+    }
+
+    Add-Content -Path $summaryPath -Value "Results:"
+    foreach ($result in $results) {
+        Add-Content -Path $summaryPath -Value ("- {0}: {1} (exit {2})" -f $result.Target, $result.Status, $result.ExitCode)
+    }
+
+    if (Test-Path $findingsPath) {
+        $findingCount = (Get-Content -Path $findingsPath | Measure-Object -Line).Lines
+    } else {
+        $findingCount = 0
+        New-Item -ItemType File -Path $findingsPath | Out-Null
+    }
+    Add-Content -Path $summaryPath -Value ""
+    Add-Content -Path $summaryPath -Value "Findings: $findingCount"
+
+    if ($KeepRuns -gt 0 -and (Test-Path $artifactsRootPath)) {
+        Get-ChildItem -Path $artifactsRootPath -Directory |
+            Where-Object { $_.Name -match '^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$' } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -Skip $KeepRuns |
+            Remove-Item -Recurse -Force
+    }
+
+    $failed = @($results | Where-Object { $_.ExitCode -ne 0 })
+    Write-Host "Artifacts saved in $runDir"
+    Write-Host "Findings written to $findingsPath"
+
+    if ($failed.Count -gt 0) {
+        exit 1
+    }
+}
+finally {
+    Pop-Location
+    $env:FUZZ_API_EXTERNAL = $previousExternal
+    $env:FUZZ_API_FINDINGS = $previousFindings
+}


### PR DESCRIPTION
## Summary

Adds a PowerShell fuzz runner that executes all HTTP fuzz targets and stores each run in a timestamped artifacts directory.

## Changes

- Add `scripts/run-fuzz.ps1` with configurable fuzz duration, target list, stop-on-failure mode, artifacts root, and retention count.
- Store per-target logs, a shared `fuzz-findings.jsonl`, and `summary.txt` for every fuzz execution.
- Document the recommended runner workflow and artifact layout in `README.md`.

## Validation

- Parsed `scripts/run-fuzz.ps1` with the PowerShell parser.
- Ran `go test ./...` using a repo-local `GOCACHE`.
- Ran `git diff --check`.

Fuzzing against the external API was not executed to avoid sending traffic during PR preparation.