### PR TITLE
[codex] limit fuzz log storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ By default the script keeps the latest 10 execution directories and removes olde
 .\scripts\run-fuzz.ps1 -FuzzTime 5m -KeepRuns 20
 ```
 
+Request bodies, response bodies, and error text are truncated to 8192 bytes before being stored in logs or findings. Override the limit with `-MaxLogBytes`; use `0` to disable truncation:
+
+```powershell
+.\scripts\run-fuzz.ps1 -FuzzTime 30s -MaxLogBytes 4096
+```
+
+For longer campaigns, keep `fuzz-findings.jsonl` and summaries but suppress per-request logging noise with `-QuietRequests`:
+
+```powershell
+.\scripts\run-fuzz.ps1 -FuzzTime 10m -QuietRequests
+```
+
 Run fuzz tests:
 
 ```bash

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,11 +6,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
 
 const defaultFindingsPath = "../artifacts/fuzz-findings.jsonl"
+const defaultMaxLogBytes = 8192
 
 var findingsMu sync.Mutex
 
@@ -28,16 +31,20 @@ type Finding struct {
 
 // LogRequest registra las solicitudes HTTP.
 func LogRequest(method, endpoint, seed string, statusCode int, duration time.Duration, requestBody, responseBody string) {
+	if !requestLoggingEnabled() {
+		return
+	}
+
 	logEntry := fmt.Sprintf(
 		"Time: %s\nMethod: %s\nEndpoint: %s\nSeed: %s\nRequest body: %s\nHTTP status: %d\nDuration: %v\nResponse: %s\n\n",
 		time.Now().Format(time.RFC3339),
 		method,
 		endpoint,
 		seed,
-		requestBody,
+		truncateLogValue(requestBody),
 		statusCode,
 		duration,
-		responseBody,
+		truncateLogValue(responseBody),
 	)
 	log.Println(logEntry)
 }
@@ -71,9 +78,9 @@ func LogFinding(method, endpoint, seed string, statusCode int, duration time.Dur
 		Seed:         seed,
 		StatusCode:   statusCode,
 		DurationMS:   duration.Milliseconds(),
-		RequestBody:  requestBody,
-		ResponseBody: responseBody,
-		Error:        errText,
+		RequestBody:  truncateLogValue(requestBody),
+		ResponseBody: truncateLogValue(responseBody),
+		Error:        truncateLogValue(errText),
 	}
 
 	if err := json.NewEncoder(file).Encode(finding); err != nil {
@@ -81,4 +88,37 @@ func LogFinding(method, endpoint, seed string, statusCode int, duration time.Dur
 	}
 
 	return nil
+}
+
+func requestLoggingEnabled() bool {
+	value := strings.TrimSpace(os.Getenv("FUZZ_API_LOG_REQUESTS"))
+	if value == "" {
+		return true
+	}
+	return value != "0" &&
+		!strings.EqualFold(value, "false") &&
+		!strings.EqualFold(value, "no") &&
+		!strings.EqualFold(value, "off")
+}
+
+func truncateLogValue(value string) string {
+	maxBytes := maxLogBytes()
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value
+	}
+
+	return value[:maxBytes] + fmt.Sprintf("... [truncated, original_bytes=%d]", len(value))
+}
+
+func maxLogBytes() int {
+	value := strings.TrimSpace(os.Getenv("FUZZ_API_MAX_LOG_BYTES"))
+	if value == "" {
+		return defaultMaxLogBytes
+	}
+
+	maxBytes, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultMaxLogBytes
+	}
+	return maxBytes
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -34,3 +34,34 @@ func TestLogFindingWritesJSONL(t *testing.T) {
 		t.Fatalf("DurationMS = %d, want 1500", finding.DurationMS)
 	}
 }
+
+func TestLogFindingTruncatesLargeValues(t *testing.T) {
+	findingsPath := filepath.Join(t.TempDir(), "findings.jsonl")
+	t.Setenv("FUZZ_API_FINDINGS", findingsPath)
+	t.Setenv("FUZZ_API_MAX_LOG_BYTES", "4")
+
+	err := LogFinding("POST", "https://example.com/api", "/api", 500, time.Second, "123456789", "abcdefghi", "timeout error")
+	if err != nil {
+		t.Fatalf("LogFinding returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(findingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+
+	var finding Finding
+	if err := json.Unmarshal(data, &finding); err != nil {
+		t.Fatalf("finding is not valid JSON: %v", err)
+	}
+
+	if finding.RequestBody != "1234... [truncated, original_bytes=9]" {
+		t.Fatalf("RequestBody = %q", finding.RequestBody)
+	}
+	if finding.ResponseBody != "abcd... [truncated, original_bytes=9]" {
+		t.Fatalf("ResponseBody = %q", finding.ResponseBody)
+	}
+	if finding.Error != "time... [truncated, original_bytes=13]" {
+		t.Fatalf("Error = %q", finding.Error)
+	}
+}

--- a/scripts/run-fuzz.ps1
+++ b/scripts/run-fuzz.ps1
@@ -3,6 +3,7 @@ param(
     [string]$FuzzTime = "30s",
     [string]$ArtifactsRoot = "artifacts",
     [int]$KeepRuns = 10,
+    [int]$MaxLogBytes = 8192,
     [string[]]$Targets = @(
         "FuzzGetEndpoint",
         "FuzzPostEndpoint",
@@ -10,7 +11,8 @@ param(
         "FuzzPatchEndpoint",
         "FuzzDeleteEndpoint"
     ),
-    [switch]$StopOnFailure
+    [switch]$StopOnFailure,
+    [switch]$QuietRequests
 )
 
 $ErrorActionPreference = "Stop"
@@ -27,6 +29,8 @@ New-Item -ItemType Directory -Force -Path $runDir | Out-Null
 
 $previousExternal = $env:FUZZ_API_EXTERNAL
 $previousFindings = $env:FUZZ_API_FINDINGS
+$previousMaxLogBytes = $env:FUZZ_API_MAX_LOG_BYTES
+$previousLogRequests = $env:FUZZ_API_LOG_REQUESTS
 $results = @()
 
 try {
@@ -34,12 +38,16 @@ try {
 
     $env:FUZZ_API_EXTERNAL = "1"
     $env:FUZZ_API_FINDINGS = $findingsPath
+    $env:FUZZ_API_MAX_LOG_BYTES = $MaxLogBytes.ToString()
+    $env:FUZZ_API_LOG_REQUESTS = if ($QuietRequests) { "0" } else { "1" }
 
     @(
         "Fuzz run: $timestamp",
         "Repository: $repoRoot",
         "Fuzz time: $FuzzTime",
         "Findings: $findingsPath",
+        "Max log bytes: $MaxLogBytes",
+        "Request logs: $(if ($QuietRequests) { 'disabled' } else { 'enabled' })",
         "Targets: $($Targets -join ', ')",
         ""
     ) | Set-Content -Path $summaryPath
@@ -113,4 +121,6 @@ finally {
     Pop-Location
     $env:FUZZ_API_EXTERNAL = $previousExternal
     $env:FUZZ_API_FINDINGS = $previousFindings
+    $env:FUZZ_API_MAX_LOG_BYTES = $previousMaxLogBytes
+    $env:FUZZ_API_LOG_REQUESTS = $previousLogRequests
 }


### PR DESCRIPTION
## Summary

Improves fuzz log storage so long-running campaigns keep useful artifacts without letting request logs grow unchecked.

## Changes

- Truncate request bodies, response bodies, and error text before writing request logs or JSONL findings.
- Add `FUZZ_API_MAX_LOG_BYTES` with an 8192-byte default and `0` support to disable truncation.
- Add `FUZZ_API_LOG_REQUESTS` support so per-request logs can be suppressed while keeping findings.
- Expose the controls in `scripts/run-fuzz.ps1` as `-MaxLogBytes` and `-QuietRequests`.
- Document the new storage controls in `README.md`.
- Add logger coverage for truncating findings.

## Validation

- Parsed `scripts/run-fuzz.ps1` with the PowerShell parser.
- Ran `go test ./...` using a repo-local `GOCACHE`.
- Ran `git diff --check`.

Fuzzing against the external API was not executed to avoid sending traffic during PR preparation.