### PR TITLE
[codex] add CI diagnostics summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     name: Go checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      CI_REPORT_DIR: reports/ci
 
     steps:
       - name: Checkout
@@ -25,21 +27,67 @@ jobs:
           cache: true
           cache-dependency-path: go.mod
 
+      - name: Prepare CI reports
+        run: mkdir -p "$CI_REPORT_DIR"
+
       - name: Verify module files
         run: |
-          go mod tidy
-          git diff --exit-code -- go.mod go.sum
+          set -o pipefail
+          {
+            go mod tidy
+            git diff --exit-code -- go.mod go.sum
+          } 2>&1 | tee "$CI_REPORT_DIR/module-files.log"
 
       - name: Check formatting
         run: |
+          set -o pipefail
           files="$(gofmt -l .)"
+          printf "%s\n" "$files" | tee "$CI_REPORT_DIR/formatting.log"
           if [ -n "$files" ]; then
-            echo "$files"
             exit 1
           fi
 
       - name: Run vet
-        run: go vet ./...
+        run: |
+          set -o pipefail
+          go vet ./... 2>&1 | tee "$CI_REPORT_DIR/vet.log"
 
       - name: Run tests
-        run: go test -race -count=1 ./...
+        run: |
+          set -o pipefail
+          go test -race -count=1 ./... 2>&1 | tee "$CI_REPORT_DIR/tests.log"
+
+      - name: Write CI diagnostics summary
+        if: always()
+        run: |
+          {
+            echo "## CI diagnostics"
+            echo ""
+            echo "- Workflow: \`${{ github.workflow }}\`"
+            echo "- Run: \`${{ github.run_id }}.${{ github.run_attempt }}\`"
+            echo "- Ref: \`${{ github.ref_name }}\`"
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo ""
+            echo "### Logs"
+            for log in "$CI_REPORT_DIR"/*.log; do
+              [ -f "$log" ] || continue
+              name="$(basename "$log")"
+              echo ""
+              echo "<details>"
+              echo "<summary>$name</summary>"
+              echo ""
+              echo '```text'
+              tail -n 80 "$log"
+              echo '```'
+              echo "</details>"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload CI diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: reports/ci
+          retention-days: 14
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Run all tests:
 go test ./...
 ```
 
+GitHub Actions writes a lightweight CI diagnostics summary for every run and uploads `reports/ci` as an artifact for 14 days. The summary includes the latest lines from module verification, formatting, vet, and test logs so failures are easier to triage from the workflow page.
+
 Run every fuzz target on PowerShell and save artifacts per execution:
 
 ```powershell


### PR DESCRIPTION
## Summary

Adds lightweight CI diagnostics to make GitHub Actions failures easier to triage without adding a separate service or AI agent.

## Changes

- Capture module verification, formatting, vet, and test output into `reports/ci/*.log`.
- Write a GitHub Actions job summary with run metadata and the last 80 lines of each available log.
- Upload `reports/ci` as a workflow artifact for 14 days.
- Document the diagnostics behavior in `README.md`.

## Validation

- Ran `go test ./...` using a repo-local `GOCACHE`.
- Ran `git diff --check`.
- Reviewed the updated workflow YAML locally.

This is intentionally lightweight: it improves CI visibility without introducing extra infrastructure.