### PR TITLE
[codex] add separated API load testing runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Fuzzing API Testing
 
-This project is a small Go framework for fuzz testing HTTP API endpoints. It currently supports GET, POST, PUT, PATCH, and DELETE requests, reads endpoint settings from `config/config.json`, and logs each request outcome.
+This project is a small Go framework for testing HTTP API endpoints. It currently has two separated testing paths:
+
+- **Fuzz testing**: Mutates endpoints and request bodies for GET, POST, PUT, PATCH, and DELETE.
+- **Load testing**: Runs a small set of configured API calls concurrently and reports basic performance metrics.
 
 ## Features
 
@@ -10,6 +13,9 @@ This project is a small Go framework for fuzz testing HTTP API endpoints. It cur
 - **JSON configuration**: Manage the base URL, endpoints, and POST body from one file.
 - **Request logging**: Log method, endpoint, seed, response status, duration, request body, and response body.
 - **Reproducible findings**: Store request errors and 5xx responses as JSON Lines artifacts for later triage.
+- **Basic load testing**: Run configured scenarios with concurrent users, fixed request counts, or duration-based execution.
+- **Load reports**: Store per-request JSON Lines logs plus summary metrics such as success count, failures, RPS, average latency, p95, and p99.
+- **Separated or combined runs**: Execute fuzzing, load testing, or both while keeping artifacts organized by test type.
 - **Local client tests**: Validate the API client without calling external services.
 
 ## Project Structure
@@ -20,17 +26,27 @@ fuzzing-api/
 |   |-- api_client.go        # API client implementation
 |   `-- api_client_test.go   # Local client tests with httptest
 |-- config/
-|   `-- config.json          # Base URL, endpoints, and request body
+|   |-- config.json          # Base URL, endpoints, and request body
+|   `-- load.json            # Load testing scenarios
+|-- cmd/
+|   `-- loadtest/
+|       `-- main.go          # Load test CLI entrypoint
 |-- fuzz/
 |   |-- fuzz_get_test.go     # GET fuzz target wrapper
 |   |-- fuzz_post_test.go    # POST fuzz target wrapper
 |   |-- fuzz_write_methods_test.go # Shared fuzz helpers plus PUT, PATCH, and DELETE wrappers
 |   `-- seeds_test.go        # Verb-specific endpoint and body seeds
+|-- load/
+|   |-- config.go            # Load test config loading and validation
+|   |-- runner.go            # Concurrent load runner and metrics aggregation
+|   `-- runner_test.go       # Local load runner tests with httptest
 |-- logger/
 |   |-- logger.go            # Request logging and findings helpers
 |   `-- logger_test.go       # Findings artifact tests
 |-- scripts/
-|   `-- run-fuzz.ps1         # PowerShell runner that stores artifacts per execution
+|   |-- run-fuzz.ps1         # PowerShell runner that stores artifacts per execution
+|   |-- run-load.ps1         # PowerShell load runner with separated artifacts
+|   `-- run-api-tests.ps1    # Combined fuzz + load runner
 |-- utils/
 |   |-- utils.go             # Configuration loading
 |   `-- validator.go         # HTTP status validator helper
@@ -58,6 +74,32 @@ The `config/config.json` file uses this shape:
     "dueDate": "2026-01-01T00:00:00Z",
     "completed": false
   }
+}
+```
+
+The `config/load.json` file keeps load testing separate from fuzzing:
+
+```json
+{
+  "baseURL": "https://example.com/api/v1",
+  "scenarios": [
+    {
+      "name": "list-resources",
+      "method": "GET",
+      "endpoint": "/resources"
+    },
+    {
+      "name": "create-resource",
+      "method": "POST",
+      "endpoint": "/resources",
+      "body": {
+        "id": 1,
+        "title": "Load Test Activity",
+        "dueDate": "2026-01-01T00:00:00Z",
+        "completed": false
+      }
+    }
+  ]
 }
 ```
 
@@ -113,6 +155,92 @@ For longer campaigns, keep `fuzz-findings.jsonl` and summaries but suppress per-
 
 ```powershell
 .\scripts\run-fuzz.ps1 -FuzzTime 10m -QuietRequests
+```
+
+Run a small load test and save artifacts separately:
+
+```powershell
+.\scripts\run-load.ps1 -Users 5 -Requests 25
+```
+
+The runner creates a timestamped directory under `artifacts/load/`:
+
+```plaintext
+artifacts/
+`-- load/
+    `-- 2026-07-04_12-00-00/
+        |-- load-console.log
+        |-- load-requests.jsonl
+        `-- summary.json
+```
+
+Use a duration-based run instead of a fixed request count:
+
+```powershell
+.\scripts\run-load.ps1 -Users 10 -Requests 0 -Duration 30s
+```
+
+Run only selected load scenarios:
+
+```powershell
+.\scripts\run-load.ps1 -Scenario list-activities,get-activity -Users 5 -Requests 20
+```
+
+### Reading API health from load results
+
+Load test results are written to `summary.json` and `load-requests.jsonl`. A small run is useful as a smoke test: it confirms that the configured API is reachable, the selected calls respond, and the runner can collect latency and status data. It is not enough by itself to prove that the API will behave well under sustained traffic.
+
+Start by checking these fields in `summary.json`:
+
+| Metric | What to check |
+| --- | --- |
+| `successful` / `totalRequests` | Availability for the tested calls. |
+| `failed` | Connection errors, timeouts, unexpected status codes, or failed requests. |
+| `statusCodes` | HTTP response distribution. Watch for `5xx` and unexpected `4xx`. |
+| `avgMs` | Normal response time across the run. |
+| `p95Ms` and `p99Ms` | Slowest user-facing responses. These matter more than the average. |
+| `requestsPerSec` | Throughput reached by the test. |
+
+An initial health guideline for small API smoke/load runs:
+
+```plaintext
+Healthy:
+- failed == 0
+- success rate >= 99%
+- no HTTP 5xx responses
+- p95Ms < 500
+- p99Ms < 1000
+```
+
+Example from a small run:
+
+```plaintext
+Requests: 10
+Success: 10
+Failed: 0
+Status codes: 200 => 10
+Avg: 95.60ms
+P95: 296ms
+P99: 296ms
+```
+
+That result is healthy for a smoke test, but confidence is still limited because it only uses a few requests. Increase users, duration, and scenario coverage gradually to evaluate sustained API health.
+
+Run fuzzing and load testing together while keeping their logs separated:
+
+```powershell
+.\scripts\run-api-tests.ps1 -FuzzTime 30s -LoadUsers 5 -LoadRequests 25 -QuietFuzzRequests
+```
+
+The combined runner writes its own summary and stores fuzz/load artifacts below the same timestamped run:
+
+```plaintext
+artifacts/
+`-- api-tests/
+    `-- 2026-07-04_12-05-00/
+        |-- summary.txt
+        |-- fuzz/
+        `-- load/
 ```
 
 Run fuzz tests:

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"fuzzing-api/api"
+	"fuzzing-api/load"
+)
+
+func main() {
+	configPath := flag.String("config", "config/load.json", "load test configuration file")
+	artifactsDir := flag.String("artifacts", "artifacts/load", "directory for load test artifacts")
+	users := flag.Int("users", 2, "number of concurrent users")
+	durationText := flag.String("duration", "", "run duration, for example 30s or 2m")
+	requests := flag.Int64("requests", 10, "total requests to execute; use 0 with -duration for duration-only runs")
+	scenarioFilter := flag.String("scenario", "", "comma-separated scenario names to run; empty runs all")
+	flag.Parse()
+
+	duration := time.Duration(0)
+	if strings.TrimSpace(*durationText) != "" {
+		parsed, err := time.ParseDuration(*durationText)
+		if err != nil {
+			exitf("invalid duration: %v", err)
+		}
+		duration = parsed
+	}
+
+	config, err := load.LoadConfig(*configPath)
+	if err != nil {
+		exitf("load config: %v", err)
+	}
+
+	scenarios := filterScenarios(config.Scenarios, *scenarioFilter)
+	if len(scenarios) == 0 {
+		exitf("no scenarios matched %q", *scenarioFilter)
+	}
+
+	if err := os.MkdirAll(*artifactsDir, 0755); err != nil {
+		exitf("create artifacts directory: %v", err)
+	}
+
+	client := api.NewAPIClient(config.BaseURL)
+	report, err := load.Run(context.Background(), client, scenarios, load.RunnerOptions{
+		Users:    *users,
+		Duration: duration,
+		Requests: *requests,
+	})
+	if err != nil {
+		exitf("run load test: %v", err)
+	}
+
+	if err := writeReport(*artifactsDir, report); err != nil {
+		exitf("write report: %v", err)
+	}
+
+	fmt.Printf("Load artifacts saved in %s\n", *artifactsDir)
+	fmt.Printf("Requests: %d, success: %d, failed: %d, rps: %.2f, avg: %.2fms, p95: %dms, p99: %dms\n",
+		report.TotalRequests,
+		report.Successful,
+		report.Failed,
+		report.RequestsPerSec,
+		report.AvgMS,
+		report.P95MS,
+		report.P99MS,
+	)
+
+	if report.Failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func filterScenarios(scenarios []load.Scenario, filter string) []load.Scenario {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return scenarios
+	}
+
+	allowed := map[string]bool{}
+	for _, name := range strings.Split(filter, ",") {
+		allowed[strings.TrimSpace(name)] = true
+	}
+
+	var selected []load.Scenario
+	for _, scenario := range scenarios {
+		if allowed[scenario.Name] {
+			selected = append(selected, scenario)
+		}
+	}
+	return selected
+}
+
+func writeReport(dir string, report *load.Report) error {
+	summaryPath := filepath.Join(dir, "summary.json")
+	samplesPath := filepath.Join(dir, "load-requests.jsonl")
+
+	summaryFile, err := os.Create(summaryPath)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(summaryFile)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		summaryFile.Close()
+		return err
+	}
+	if err := summaryFile.Close(); err != nil {
+		return err
+	}
+
+	samplesFile, err := os.Create(samplesPath)
+	if err != nil {
+		return err
+	}
+	encoder = json.NewEncoder(samplesFile)
+	for _, sample := range report.Samples {
+		if err := encoder.Encode(sample); err != nil {
+			samplesFile.Close()
+			return err
+		}
+	}
+	return samplesFile.Close()
+}
+
+func exitf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/config/load.json
+++ b/config/load.json
@@ -1,0 +1,26 @@
+{
+  "baseURL": "https://fakerestapi.azurewebsites.net/api/v1",
+  "scenarios": [
+    {
+      "name": "list-activities",
+      "method": "GET",
+      "endpoint": "/Activities"
+    },
+    {
+      "name": "get-activity",
+      "method": "GET",
+      "endpoint": "/Activities/1"
+    },
+    {
+      "name": "create-activity",
+      "method": "POST",
+      "endpoint": "/Activities",
+      "body": {
+        "id": 1,
+        "title": "Load Test Activity",
+        "dueDate": "2026-01-01T00:00:00Z",
+        "completed": false
+      }
+    }
+  ]
+}

--- a/load/config.go
+++ b/load/config.go
@@ -1,0 +1,61 @@
+package load
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Config struct {
+	BaseURL   string     `json:"baseURL"`
+	Scenarios []Scenario `json:"scenarios"`
+}
+
+type Scenario struct {
+	Name     string          `json:"name"`
+	Method   string          `json:"method"`
+	Endpoint string          `json:"endpoint"`
+	Body     json.RawMessage `json:"body,omitempty"`
+}
+
+func LoadConfig(path string) (*Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var config Config
+	if err := json.NewDecoder(file).Decode(&config); err != nil {
+		return nil, err
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return fmt.Errorf("baseURL is required")
+	}
+	if len(c.Scenarios) == 0 {
+		return fmt.Errorf("at least one scenario is required")
+	}
+
+	for i, scenario := range c.Scenarios {
+		if strings.TrimSpace(scenario.Name) == "" {
+			return fmt.Errorf("scenario %d name is required", i)
+		}
+		if strings.TrimSpace(scenario.Method) == "" {
+			return fmt.Errorf("scenario %q method is required", scenario.Name)
+		}
+		if strings.TrimSpace(scenario.Endpoint) == "" {
+			return fmt.Errorf("scenario %q endpoint is required", scenario.Name)
+		}
+	}
+
+	return nil
+}

--- a/load/runner.go
+++ b/load/runner.go
@@ -1,0 +1,196 @@
+package load
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"fuzzing-api/api"
+)
+
+type RunnerOptions struct {
+	Users    int
+	Duration time.Duration
+	Requests int64
+}
+
+type Sample struct {
+	Timestamp  string `json:"timestamp"`
+	Scenario   string `json:"scenario"`
+	Method     string `json:"method"`
+	Endpoint   string `json:"endpoint"`
+	StatusCode int    `json:"statusCode"`
+	DurationMS int64  `json:"durationMs"`
+	Error      string `json:"error,omitempty"`
+}
+
+type Report struct {
+	StartedAt       string         `json:"startedAt"`
+	FinishedAt      string         `json:"finishedAt"`
+	Users           int            `json:"users"`
+	DurationSeconds float64        `json:"durationSeconds"`
+	TotalRequests   int            `json:"totalRequests"`
+	Successful      int            `json:"successful"`
+	Failed          int            `json:"failed"`
+	RequestsPerSec  float64        `json:"requestsPerSec"`
+	MinMS           int64          `json:"minMs"`
+	AvgMS           float64        `json:"avgMs"`
+	P95MS           int64          `json:"p95Ms"`
+	P99MS           int64          `json:"p99Ms"`
+	MaxMS           int64          `json:"maxMs"`
+	StatusCodes     map[string]int `json:"statusCodes"`
+	Samples         []Sample       `json:"-"`
+}
+
+func Run(ctx context.Context, client *api.APIClient, scenarios []Scenario, options RunnerOptions) (*Report, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	if len(scenarios) == 0 {
+		return nil, fmt.Errorf("at least one scenario is required")
+	}
+	if options.Users <= 0 {
+		options.Users = 1
+	}
+	if options.Duration <= 0 && options.Requests <= 0 {
+		options.Requests = int64(len(scenarios))
+	}
+
+	runCtx := ctx
+	cancel := func() {}
+	if options.Duration > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, options.Duration)
+	}
+	defer cancel()
+
+	started := time.Now()
+	var issued int64
+	samples := make(chan Sample, options.Users*2)
+	var wg sync.WaitGroup
+
+	for user := 0; user < options.Users; user++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for {
+				current := atomic.AddInt64(&issued, 1)
+				if options.Requests > 0 && current > options.Requests {
+					return
+				}
+
+				select {
+				case <-runCtx.Done():
+					return
+				default:
+				}
+
+				scenario := scenarios[(int(current)-1+offset)%len(scenarios)]
+				samples <- executeScenario(client, scenario)
+			}
+		}(user)
+	}
+
+	go func() {
+		wg.Wait()
+		close(samples)
+	}()
+
+	report := &Report{
+		StartedAt:   started.Format(time.RFC3339),
+		Users:       options.Users,
+		StatusCodes: map[string]int{},
+	}
+	var durations []int64
+	var totalDuration int64
+
+	for sample := range samples {
+		report.Samples = append(report.Samples, sample)
+		report.TotalRequests++
+		durations = append(durations, sample.DurationMS)
+		totalDuration += sample.DurationMS
+
+		if sample.Error == "" && sample.StatusCode >= 200 && sample.StatusCode < 400 {
+			report.Successful++
+		} else {
+			report.Failed++
+		}
+		report.StatusCodes[statusKey(sample)]++
+	}
+
+	finished := time.Now()
+	report.FinishedAt = finished.Format(time.RFC3339)
+	report.DurationSeconds = finished.Sub(started).Seconds()
+	if report.DurationSeconds > 0 {
+		report.RequestsPerSec = float64(report.TotalRequests) / report.DurationSeconds
+	}
+	if report.TotalRequests > 0 {
+		sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+		report.MinMS = durations[0]
+		report.MaxMS = durations[len(durations)-1]
+		report.AvgMS = float64(totalDuration) / float64(report.TotalRequests)
+		report.P95MS = percentile(durations, 0.95)
+		report.P99MS = percentile(durations, 0.99)
+	}
+
+	return report, nil
+}
+
+func executeScenario(client *api.APIClient, scenario Scenario) Sample {
+	method := strings.ToUpper(strings.TrimSpace(scenario.Method))
+	body := ""
+	if len(scenario.Body) > 0 && string(scenario.Body) != "null" {
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, scenario.Body); err == nil {
+			body = compact.String()
+		} else {
+			body = string(scenario.Body)
+		}
+	}
+
+	resp, statusCode, duration, err := client.Request(method, scenario.Endpoint, body)
+	if resp != nil && resp.Body != nil {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	sample := Sample{
+		Timestamp:  time.Now().Format(time.RFC3339),
+		Scenario:   scenario.Name,
+		Method:     method,
+		Endpoint:   scenario.Endpoint,
+		StatusCode: statusCode,
+		DurationMS: duration.Milliseconds(),
+	}
+	if err != nil {
+		sample.Error = err.Error()
+	}
+	return sample
+}
+
+func percentile(values []int64, rank float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	index := int(rank*float64(len(values)) + 0.5)
+	if index < 1 {
+		index = 1
+	}
+	if index > len(values) {
+		index = len(values)
+	}
+	return values[index-1]
+}
+
+func statusKey(sample Sample) string {
+	if sample.Error != "" && sample.StatusCode == 0 {
+		return "error"
+	}
+	return fmt.Sprintf("%d", sample.StatusCode)
+}

--- a/load/runner_test.go
+++ b/load/runner_test.go
@@ -1,0 +1,85 @@
+package load
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"fuzzing-api/api"
+)
+
+func TestRunExecutesConfiguredRequests(t *testing.T) {
+	var seen int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := api.NewAPIClient(server.URL)
+	report, err := Run(context.Background(), client, []Scenario{
+		{Name: "health", Method: http.MethodGet, Endpoint: "/health"},
+	}, RunnerOptions{
+		Users:    2,
+		Requests: 5,
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if seen != 5 {
+		t.Fatalf("seen = %d, want 5", seen)
+	}
+	if report.TotalRequests != 5 || report.Successful != 5 || report.Failed != 0 {
+		t.Fatalf("report = %+v", report)
+	}
+	if len(report.Samples) != 5 {
+		t.Fatalf("samples = %d, want 5", len(report.Samples))
+	}
+}
+
+func TestRunUsesDefaultRequestCount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client := api.NewAPIClient(server.URL)
+	report, err := Run(context.Background(), client, []Scenario{
+		{Name: "one", Method: http.MethodPost, Endpoint: "/one", Body: []byte(`{"id":1}`)},
+		{Name: "two", Method: http.MethodGet, Endpoint: "/two"},
+	}, RunnerOptions{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if report.TotalRequests != 2 {
+		t.Fatalf("TotalRequests = %d, want 2", report.TotalRequests)
+	}
+	if report.Users != 1 {
+		t.Fatalf("Users = %d, want 1", report.Users)
+	}
+}
+
+func TestRunStopsOnDuration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := api.NewAPIClient(server.URL)
+	report, err := Run(context.Background(), client, []Scenario{
+		{Name: "loop", Method: http.MethodGet, Endpoint: "/loop"},
+	}, RunnerOptions{
+		Users:    1,
+		Duration: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if report.TotalRequests == 0 {
+		t.Fatal("TotalRequests = 0, want at least one request")
+	}
+}

--- a/load/runner_test.go
+++ b/load/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,9 +12,9 @@ import (
 )
 
 func TestRunExecutesConfiguredRequests(t *testing.T) {
-	var seen int
+	var seen int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		seen++
+		atomic.AddInt64(&seen, 1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -29,8 +30,8 @@ func TestRunExecutesConfiguredRequests(t *testing.T) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
-	if seen != 5 {
-		t.Fatalf("seen = %d, want 5", seen)
+	if got := atomic.LoadInt64(&seen); got != 5 {
+		t.Fatalf("seen = %d, want 5", got)
 	}
 	if report.TotalRequests != 5 || report.Successful != 5 || report.Failed != 0 {
 		t.Fatalf("report = %+v", report)

--- a/scripts/run-api-tests.ps1
+++ b/scripts/run-api-tests.ps1
@@ -1,0 +1,78 @@
+[CmdletBinding()]
+param(
+    [string]$FuzzTime = "30s",
+    [int]$LoadUsers = 2,
+    [int]$LoadRequests = 10,
+    [string]$LoadDuration = "",
+    [string]$ArtifactsRoot = "artifacts/api-tests",
+    [int]$KeepRuns = 10,
+    [switch]$QuietFuzzRequests
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+$combinedRoot = Join-Path $repoRoot $ArtifactsRoot
+$runDir = Join-Path $combinedRoot $timestamp
+$summaryPath = Join-Path $runDir "summary.txt"
+$relativeFuzzRoot = Join-Path $ArtifactsRoot "$timestamp/fuzz"
+$relativeLoadRoot = Join-Path $ArtifactsRoot "$timestamp/load"
+$results = @()
+
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+try {
+    Push-Location $repoRoot
+
+    @(
+        "Combined API test run: $timestamp",
+        "Repository: $repoRoot",
+        "Fuzz time: $FuzzTime",
+        "Load users: $LoadUsers",
+        "Load requests: $LoadRequests",
+        "Load duration: $LoadDuration",
+        ""
+    ) | Set-Content -Path $summaryPath
+
+    $powerShellExe = (Get-Process -Id $PID).Path
+
+    $fuzzArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "$PSScriptRoot\run-fuzz.ps1", "-FuzzTime", $FuzzTime, "-ArtifactsRoot", $relativeFuzzRoot, "-KeepRuns", "0")
+    if ($QuietFuzzRequests) {
+        $fuzzArgs += "-QuietRequests"
+    }
+    & $powerShellExe @fuzzArgs
+    $fuzzExit = $LASTEXITCODE
+    $results += [pscustomobject]@{ Name = "fuzz"; ExitCode = $fuzzExit }
+
+    $loadArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "$PSScriptRoot\run-load.ps1", "-ArtifactsRoot", $relativeLoadRoot, "-Users", $LoadUsers.ToString(), "-Requests", $LoadRequests.ToString(), "-KeepRuns", "0")
+    if ($LoadDuration -ne "") {
+        $loadArgs += @("-Duration", $LoadDuration)
+    }
+    & $powerShellExe @loadArgs
+    $loadExit = $LASTEXITCODE
+    $results += [pscustomobject]@{ Name = "load"; ExitCode = $loadExit }
+
+    Add-Content -Path $summaryPath -Value "Results:"
+    foreach ($result in $results) {
+        $status = if ($result.ExitCode -eq 0) { "PASS" } else { "FAIL" }
+        Add-Content -Path $summaryPath -Value ("- {0}: {1} (exit {2})" -f $result.Name, $status, $result.ExitCode)
+    }
+
+    if ($KeepRuns -gt 0 -and (Test-Path $combinedRoot)) {
+        Get-ChildItem -Path $combinedRoot -Directory |
+            Where-Object { $_.Name -match '^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$' } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -Skip $KeepRuns |
+            Remove-Item -Recurse -Force
+    }
+
+    Write-Host "Combined API test artifacts saved in $runDir"
+    if (($results | Where-Object { $_.ExitCode -ne 0 }).Count -gt 0) {
+        exit 1
+    }
+}
+finally {
+    Pop-Location
+}

--- a/scripts/run-load.ps1
+++ b/scripts/run-load.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+param(
+    [string]$Config = "config/load.json",
+    [string]$ArtifactsRoot = "artifacts/load",
+    [int]$Users = 2,
+    [string]$Duration = "",
+    [int]$Requests = 10,
+    [string]$Scenario = "",
+    [int]$KeepRuns = 10
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+$artifactsRootPath = Join-Path $repoRoot $ArtifactsRoot
+$runDir = Join-Path $artifactsRootPath $timestamp
+$consoleLogPath = Join-Path $runDir "load-console.log"
+
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$previousGoCache = $env:GOCACHE
+
+try {
+    Push-Location $repoRoot
+
+    $env:GOCACHE = Join-Path $repoRoot ".gocache"
+
+    $argsList = @(
+        "run",
+        "./cmd/loadtest",
+        "-config", $Config,
+        "-artifacts", $runDir,
+        "-users", $Users.ToString(),
+        "-requests", $Requests.ToString()
+    )
+
+    if ($Duration -ne "") {
+        $argsList += @("-duration", $Duration)
+    }
+    if ($Scenario -ne "") {
+        $argsList += @("-scenario", $Scenario)
+    }
+
+    @(
+        "Load run: $timestamp",
+        "Repository: $repoRoot",
+        "Config: $Config",
+        "Users: $Users",
+        "Requests: $Requests",
+        "Duration: $Duration",
+        "Scenario: $Scenario",
+        ""
+    ) | Set-Content -Path $consoleLogPath
+
+    & go @argsList *>&1 | Tee-Object -FilePath $consoleLogPath -Append
+    $exitCode = $LASTEXITCODE
+
+    if ($KeepRuns -gt 0 -and (Test-Path $artifactsRootPath)) {
+        Get-ChildItem -Path $artifactsRootPath -Directory |
+            Where-Object { $_.Name -match '^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$' } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -Skip $KeepRuns |
+            Remove-Item -Recurse -Force
+    }
+
+    Write-Host "Load artifacts saved in $runDir"
+    exit $exitCode
+}
+finally {
+    Pop-Location
+    $env:GOCACHE = $previousGoCache
+}


### PR DESCRIPTION
## Summary

Adds a separated load testing path alongside the existing fuzz testing workflow.

## What changed

- Added `config/load.json` with a small initial set of API load scenarios.
- Added a `load` package with concurrent execution, per-request samples, summary metrics, and unit tests.
- Added `cmd/loadtest` as the load testing CLI entrypoint.
- Added `scripts/run-load.ps1` for separated load runs and `scripts/run-api-tests.ps1` for combined fuzz + load runs.
- Updated the README with usage, artifact layout, combined testing options, and an initial guide for reading API health from load results.

## Impact

The project can now run fuzz tests and load tests independently, or together, while keeping logs and artifacts separated. This keeps the first performance-testing step small and easy to grow later.

## Validation

- `go test ./...`
- `./scripts/run-load.ps1 -Users 5 -Requests 25`

Latest load smoke result:

```text
Requests: 25
Success: 25
Failed: 0
Status codes: 200 => 25
RPS: 46.02
Avg: 106.68ms
P95: 355ms
P99: 358ms
```